### PR TITLE
versioncmp error on PE2015.2

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,7 +18,7 @@ class gitolite::params {
       }
     }
     'RedHat': {
-      if versioncmp($::operatingsystemrelease, 6) < 0 {
+      if versioncmp($::operatingsystemrelease, '6') < 0 {
         $package_name = 'gitolite'
         $cmd_install  = 'gl-setup -q'
       } else {


### PR DESCRIPTION
Using Puppet 4.2.1 on PE2015.2 using this module throws an error, complaining that it found a number instead of a string. This is a quick fix.
