### PR TITLE
add umask parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Tells Puppet what content of administration SSH key to add to Gitolite. Exclusiv
 This setting of `.gitolite.rc` file allows the repo admin to define acceptable gitconfig keys. Valid options: string. Default value: empty
 For more details, see : http://gitolite.com/gitolite/rc.html#specific-variables
 
+##### `umask`
+
+This setting of `.gitolite.rc` file controls file permissions for gitolite repositories.  Set this to 0027, for example, to allow the `group_name` group to read newly created repos.  Default value: 0077
+
 ##### `allow_local_code`
 
 Tells Puppet whether the `LOCAL_CODE` setting of `.gitolite.rc` file is enabled. Valid options: boolean. Default value: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class gitolite (
   $admin_key_source  = undef,
   $admin_key_content = undef,
   $git_config_keys   = $gitolite::params::git_config_keys,
+  $umask             = $gitolite::params::umask,
   $allow_local_code  = $gitolite::params::allow_local_code,
 ) inherits gitolite::params {
   validate_string($package_ensure)
@@ -26,6 +27,7 @@ class gitolite (
   }
 
   validate_string($git_config_keys)
+  validate_re($umask, '^0[0-7][0-7][0-7]$')
   validate_bool($allow_local_code)
 
   anchor { "${module_name}::begin": } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,5 +33,6 @@ class gitolite::params {
 
   $home_dir         = "/var/lib/${package_name}"
   $git_config_keys  = ''
+  $umask            = 0077
   $allow_local_code = false
 }

--- a/templates/gitolite3.rc.erb
+++ b/templates/gitolite3.rc.erb
@@ -21,7 +21,7 @@
 
     # default umask gives you perms of '0700'; see the rc file docs for
     # how/why you might change this
-    UMASK                           =>  0077,
+    UMASK                           =>  <%= @umask %>,
 
     # look for "git-config" in the documentation
     GIT_CONFIG_KEYS                 =>  '<%= @git_config_keys %>',


### PR DESCRIPTION
I needed to set umask when installing gitweb, so (when webserver user is added to the git group) gitweb can read the local repos.
