### PR TITLE
Fix spec tests by specifying :lsbdistcodename

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,9 +9,9 @@ describe 'gitolite', :type => 'class' do
       let (:facts) do
         case system
         when 'RedHat'
-          super().merge({ :osfamily => system, :operatingsystemrelease=> '7.0' })
+          super().merge({ :osfamily => system, :operatingsystemrelease => '7.0' })
         else
-          super().merge({ :osfamily => system })
+          super().merge({ :osfamily => system, :lsbdistcodename => 'jessie' })
         end
       end
 


### PR DESCRIPTION
Debian tests expect that to be set, otherwise spec tests fail.
This should fix the travis-ci build error as well, I believe.