### PR TITLE
Fix: The 'pe' requirement is no longer supported by the Forge.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -69,10 +69,6 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">= 3.2.0 < 5.0.0"
-    },
-    {
       "name": "puppet",
       "version_requirement": ">= 3.0.0 < 5.0.0"
     }


### PR DESCRIPTION
Most of tests failed due to "The 'pe' requirement is no longer supported by the Forge." error.

This commit removes 'pe' from `metadata.json `as its no longer supported.